### PR TITLE
feat: PainPoint CRUD APIの実装 (#5)

### DIFF
--- a/backend/app/controllers/api/v1/pain_points_controller.rb
+++ b/backend/app/controllers/api/v1/pain_points_controller.rb
@@ -1,0 +1,148 @@
+class Api::V1::PainPointsController < ApplicationController
+  before_action :require_login
+  before_action :set_pain_point, only: [:show, :update, :destroy]
+
+  def index
+    @pain_points = current_user.pain_points.includes(:tags)
+    
+    # ソート機能
+    @pain_points = case params[:sort]
+                   when 'created_at_asc'
+                     @pain_points.ordered_by_created_at(:asc)
+                   when 'created_at_desc'
+                     @pain_points.ordered_by_created_at(:desc)
+                   when 'importance_asc'
+                     @pain_points.ordered_by_importance(:asc)
+                   when 'importance_desc'
+                     @pain_points.ordered_by_importance(:desc)
+                   else
+                     @pain_points.ordered_by_created_at(:desc)
+                   end
+
+    # 重要度フィルタ
+    @pain_points = @pain_points.by_importance(params[:importance]) if params[:importance].present?
+
+    # ページネーション
+    page = params[:page]&.to_i || 1
+    per_page = params[:per_page]&.to_i || 10
+    per_page = [per_page, 50].min # 最大50件まで
+
+    @pain_points = @pain_points.limit(per_page).offset((page - 1) * per_page)
+    total_count = current_user.pain_points.count
+
+    render json: {
+      pain_points: @pain_points.map { |pain_point| pain_point_response(pain_point) },
+      pagination: {
+        current_page: page,
+        per_page: per_page,
+        total_count: total_count,
+        total_pages: (total_count / per_page.to_f).ceil
+      }
+    }
+  end
+
+  def show
+    render json: {
+      pain_point: pain_point_response(@pain_point)
+    }
+  end
+
+  def create
+    @pain_point = current_user.pain_points.build(pain_point_params)
+    
+    if @pain_point.save
+      # タグの関連付け
+      attach_tags(@pain_point, params[:tags]) if params[:tags].present?
+      
+      render json: {
+        message: 'ペインポイントを作成しました',
+        pain_point: pain_point_response(@pain_point)
+      }, status: :created
+    else
+      render json: {
+        message: 'ペインポイントの作成に失敗しました',
+        errors: @pain_point.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @pain_point.update(pain_point_params)
+      # タグの更新
+      if params[:tags].present?
+        @pain_point.pain_point_tags.destroy_all
+        attach_tags(@pain_point, params[:tags])
+      end
+      
+      render json: {
+        message: 'ペインポイントを更新しました',
+        pain_point: pain_point_response(@pain_point)
+      }
+    else
+      render json: {
+        message: 'ペインポイントの更新に失敗しました',
+        errors: @pain_point.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @pain_point.destroy
+    render json: {
+      message: 'ペインポイントを削除しました'
+    }
+  end
+
+  def quick_create
+    @pain_point = current_user.pain_points.build(
+      title: params[:title],
+      importance: 3 # デフォルト値
+    )
+    
+    if @pain_point.save
+      render json: {
+        message: 'ペインポイントをクイック作成しました',
+        pain_point: pain_point_response(@pain_point)
+      }, status: :created
+    else
+      render json: {
+        message: 'ペインポイントの作成に失敗しました',
+        errors: @pain_point.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_pain_point
+    @pain_point = current_user.pain_points.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: {
+      message: 'ペインポイントが見つかりません'
+    }, status: :not_found
+  end
+
+  def pain_point_params
+    params.require(:pain_point).permit(:title, :description, :importance, images: [])
+  end
+
+  def pain_point_response(pain_point)
+    {
+      id: pain_point.id,
+      title: pain_point.title,
+      description: pain_point.description,
+      importance: pain_point.importance,
+      tags: pain_point.tags.map { |tag| { id: tag.id, name: tag.name } },
+      images: pain_point.images.attached? ? pain_point.images.map { |image| rails_blob_url(image) } : [],
+      created_at: pain_point.created_at,
+      updated_at: pain_point.updated_at
+    }
+  end
+
+  def attach_tags(pain_point, tag_names)
+    tag_names.each do |tag_name|
+      tag = Tag.find_or_create_by(name: tag_name.downcase)
+      pain_point.pain_point_tags.find_or_create_by(tag: tag)
+    end
+  end
+end

--- a/backend/app/models/pain_point.rb
+++ b/backend/app/models/pain_point.rb
@@ -2,9 +2,14 @@ class PainPoint < ApplicationRecord
   belongs_to :user
   
   validates :title, presence: true, length: { maximum: 200 }
+  validates :importance, presence: true, inclusion: { in: 1..5 }
   
   has_many :pain_point_tags, dependent: :destroy
   has_many :tags, through: :pain_point_tags
   has_one :ai_conversation, dependent: :destroy
   has_many_attached :images
+
+  scope :by_importance, ->(importance) { where(importance: importance) }
+  scope :ordered_by_created_at, ->(direction = :desc) { order(created_at: direction) }
+  scope :ordered_by_importance, ->(direction = :desc) { order(importance: direction) }
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -2,6 +2,13 @@ Rails.application.routes.draw do
   # API routes
   namespace :api do
     namespace :v1 do
+      # Pain Points routes
+      resources :pain_points, except: [:new, :edit] do
+        collection do
+          post :quick_create
+        end
+      end
+      
       # Authentication routes
       post 'auth/signup', to: 'auth#signup'
       post 'auth/login', to: 'auth#login'

--- a/backend/db/migrate/20250702085038_add_importance_to_pain_points.rb
+++ b/backend/db/migrate/20250702085038_add_importance_to_pain_points.rb
@@ -1,0 +1,5 @@
+class AddImportanceToPainPoints < ActiveRecord::Migration[7.2]
+  def change
+    add_column :pain_points, :importance, :integer, default: 3
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_02_081524) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_02_085038) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,6 +78,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_02_081524) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "importance", default: 3
     t.index ["user_id"], name: "index_pain_points_on_user_id"
   end
 

--- a/backend/test/controllers/api/v1/pain_points_controller_test.rb
+++ b/backend/test/controllers/api/v1/pain_points_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class Api::V1::PainPointsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get api_v1_pain_points_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get api_v1_pain_points_show_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get api_v1_pain_points_create_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get api_v1_pain_points_update_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get api_v1_pain_points_destroy_url
+    assert_response :success
+  end
+
+  test "should get quick_create" do
+    get api_v1_pain_points_quick_create_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
- Issue #5 のPainPoint CRUD APIを実装
- 認証機能を活用したユーザー専用データ管理
- ページネーション、ソート、フィルタリング機能を完備
- クイック登録による素早い課題記録機能

### 実装内容
- 完全なCRUD操作API (GET, POST, PATCH, DELETE)
- クイック登録エンドポイント (POST /api/v1/pain_points/quick_create)
- ページネーション機能 (page, per_page パラメータ)
- ソート機能 (日付・重要度による昇順/降順)
- 重要度フィルタ機能 (1-5段階)
- タグ自動作成・関連付け機能
- ActiveStorage画像アップロード対応

### 編集ファイル
- app/models/pain_point.rb: 重要度バリデーション・スコープ追加
- app/controllers/api/v1/pain_points_controller.rb: CRUD API実装
- config/routes.rb: RESTfulルート設定
- db/migrate/: 重要度フィールド追加マイグレーション

🤖 Generated with [Claude Code](https://claude.ai/code)