### PR TITLE
feat: ペインポイントのクイック登録機能の実装 (#6)

### DIFF
--- a/backend/app/controllers/api/v1/pain_points_controller.rb
+++ b/backend/app/controllers/api/v1/pain_points_controller.rb
@@ -95,7 +95,7 @@ class Api::V1::PainPointsController < ApplicationController
 
   def quick_create
     @pain_point = current_user.pain_points.build(
-      title: params[:title],
+      title: params[:content],
       importance: 3 # デフォルト値
     )
     

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,11 +3,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       # Pain Points routes
-      resources :pain_points, except: [:new, :edit] do
-        collection do
-          post :quick_create
-        end
-      end
+      resources :pain_points, except: [:new, :edit]
+      post 'pain_points/quick', to: 'pain_points#quick_create'
       
       # Authentication routes
       post 'auth/signup', to: 'auth#signup'

--- a/backend/spec/requests/api/v1/pain_points_quick_create_spec.rb
+++ b/backend/spec/requests/api/v1/pain_points_quick_create_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::PainPoints Quick Create", type: :request do
+  let(:user) { create(:user) }
+  let(:token) { JsonWebToken.encode(user_id: user.id) }
+  let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+
+  describe "POST /api/v1/pain_points/quick" do
+    context "認証済みユーザーの場合" do
+      context "有効なcontentを送信した場合" do
+        it "ペインポイントが作成される" do
+          expect {
+            post "/api/v1/pain_points/quick", 
+              params: { content: "通勤電車が混雑していて不快" },
+              headers: headers
+          }.to change(PainPoint, :count).by(1)
+
+          expect(response).to have_http_status(:created)
+          json = JSON.parse(response.body)
+          expect(json['message']).to eq('ペインポイントをクイック作成しました')
+          expect(json['pain_point']['title']).to eq('通勤電車が混雑していて不快')
+          expect(json['pain_point']['importance']).to eq(3)
+        end
+      end
+
+      context "空のcontentを送信した場合" do
+        it "ペインポイントが作成されない" do
+          expect {
+            post "/api/v1/pain_points/quick", 
+              params: { content: "" },
+              headers: headers
+          }.not_to change(PainPoint, :count)
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          json = JSON.parse(response.body)
+          expect(json['message']).to eq('ペインポイントの作成に失敗しました')
+          expect(json['errors']).to include("Title can't be blank")
+        end
+      end
+
+      context "nilのcontentを送信した場合" do
+        it "ペインポイントが作成されない" do
+          expect {
+            post "/api/v1/pain_points/quick", 
+              params: { content: nil },
+              headers: headers
+          }.not_to change(PainPoint, :count)
+
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    context "未認証ユーザーの場合" do
+      it "401エラーが返される" do
+        expect {
+          post "/api/v1/pain_points/quick", 
+            params: { content: "テストペインポイント" }
+        }.not_to change(PainPoint, :count)
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/backend/test/controllers/api/v1/pain_points_controller_test.rb
+++ b/backend/test/controllers/api/v1/pain_points_controller_test.rb
@@ -1,33 +1,61 @@
 require "test_helper"
 
 class Api::V1::PainPointsControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get api_v1_pain_points_index_url
-    assert_response :success
+  def setup
+    @user = User.create!(
+      email: 'test@example.com',
+      password: 'password123',
+      password_confirmation: 'password123'
+    )
+    
+    # ログインしてトークンを取得
+    post api_v1_auth_login_path, params: { email: @user.email, password: 'password123' }
+    @token = JSON.parse(response.body)['token']
+    @headers = { 'Authorization' => "Bearer #{@token}" }
   end
 
-  test "should get show" do
-    get api_v1_pain_points_show_url
-    assert_response :success
+  test "should quick create pain point with valid content" do
+    assert_difference('PainPoint.count', 1) do
+      post api_v1_pain_points_quick_path, 
+        params: { content: '通勤電車が混雑していて不快' },
+        headers: @headers
+    end
+
+    assert_response :created
+    json_response = JSON.parse(response.body)
+    assert_equal 'ペインポイントをクイック作成しました', json_response['message']
+    assert_equal '通勤電車が混雑していて不快', json_response['pain_point']['title']
+    assert_equal 3, json_response['pain_point']['importance']
   end
 
-  test "should get create" do
-    get api_v1_pain_points_create_url
-    assert_response :success
+  test "should not quick create pain point without content" do
+    assert_no_difference('PainPoint.count') do
+      post api_v1_pain_points_quick_path, 
+        params: { content: '' },
+        headers: @headers
+    end
+
+    assert_response :unprocessable_entity
+    json_response = JSON.parse(response.body)
+    assert_equal 'ペインポイントの作成に失敗しました', json_response['message']
   end
 
-  test "should get update" do
-    get api_v1_pain_points_update_url
-    assert_response :success
+  test "should not quick create pain point without authentication" do
+    assert_no_difference('PainPoint.count') do
+      post api_v1_pain_points_quick_path, 
+        params: { content: 'テストペインポイント' }
+    end
+
+    assert_response :unauthorized
   end
 
-  test "should get destroy" do
-    get api_v1_pain_points_destroy_url
-    assert_response :success
-  end
+  test "should not quick create pain point with nil content" do
+    assert_no_difference('PainPoint.count') do
+      post api_v1_pain_points_quick_path, 
+        params: { content: nil },
+        headers: @headers
+    end
 
-  test "should get quick_create" do
-    get api_v1_pain_points_quick_create_url
-    assert_response :success
+    assert_response :unprocessable_entity
   end
 end

--- a/backend/test/fixtures/tags.yml
+++ b/backend/test/fixtures/tags.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: MyString
+  name: work
 
 two:
-  name: MyString
+  name: personal

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -24,3 +24,18 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.3s ease-out;
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,103 +1,38 @@
-import Image from "next/image";
+import QuickRegistration from "@/components/QuickRegistration";
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="container mx-auto px-4 py-8">
+        <header className="text-center mb-12">
+          <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+            CatIdea
+          </h1>
+          <p className="text-lg text-gray-600 dark:text-gray-300">
+            日常の課題をアイデアの種に変える
+          </p>
+        </header>
+        
+        <section className="mb-16">
+          <h2 className="text-2xl font-semibold text-gray-800 dark:text-gray-200 mb-6 text-center">
+            ペインポイントをクイック登録
+          </h2>
+          <QuickRegistration />
+        </section>
+        
+        <section className="max-w-4xl mx-auto">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+            <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">
+              使い方
+            </h3>
+            <ol className="list-decimal list-inside space-y-2 text-gray-600 dark:text-gray-300">
+              <li>日常で感じた課題や不便なことを入力</li>
+              <li>エンターキーですぐに保存</li>
+              <li>後でじっくり分析し、アイデアへと昇華</li>
+            </ol>
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/frontend/components/QuickRegistration.tsx
+++ b/frontend/components/QuickRegistration.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState, FormEvent, KeyboardEvent } from 'react'
+
+interface QuickRegistrationProps {
+  onSuccess?: () => void
+}
+
+export default function QuickRegistration({ onSuccess }: QuickRegistrationProps) {
+  const [content, setContent] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [message, setMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null)
+
+  const handleSubmit = async (e?: FormEvent) => {
+    e?.preventDefault()
+    
+    if (!content.trim()) return
+    
+    setIsLoading(true)
+    setMessage(null)
+    
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/pain_points/quick`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify({ content: content.trim() }),
+      })
+      
+      if (!response.ok) {
+        throw new Error('登録に失敗しました')
+      }
+      
+      setContent('')
+      setMessage({ type: 'success', text: 'ペインポイントを登録しました' })
+      onSuccess?.()
+      
+      setTimeout(() => setMessage(null), 3000)
+    } catch (error) {
+      setMessage({ type: 'error', text: '登録に失敗しました' })
+      setTimeout(() => setMessage(null), 3000)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  return (
+    <div className="w-full max-w-2xl mx-auto p-4">
+      <form onSubmit={handleSubmit} className="relative">
+        <input
+          type="text"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="今感じている課題を入力してください..."
+          className="w-full px-4 py-3 pr-12 rounded-lg border border-gray-300 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none transition-colors text-base md:text-sm"
+          disabled={isLoading}
+          autoComplete="off"
+          enterKeyHint="send"
+        />
+        <button
+          type="submit"
+          disabled={isLoading || !content.trim()}
+          className="absolute right-2 top-1/2 -translate-y-1/2 p-2 rounded-md hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          aria-label="送信"
+        >
+          {isLoading ? (
+            <svg className="animate-spin h-5 w-5 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+          ) : (
+            <svg className="h-5 w-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+            </svg>
+          )}
+        </button>
+      </form>
+      
+      {message && (
+        <div className={`mt-2 text-sm ${message.type === 'success' ? 'text-green-600' : 'text-red-600'} animate-fade-in`}>
+          {message.text}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/test/components/QuickRegistration.test.tsx
+++ b/frontend/test/components/QuickRegistration.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import QuickRegistration from '@/components/QuickRegistration'
+
+// Fetchのモック
+global.fetch = jest.fn()
+
+describe('QuickRegistration', () => {
+  beforeEach(() => {
+    (fetch as jest.Mock).mockClear()
+  })
+
+  it('入力フィールドとボタンが表示される', () => {
+    render(<QuickRegistration />)
+    
+    expect(screen.getByPlaceholderText('今感じている課題を入力してください...')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '送信' })).toBeInTheDocument()
+  })
+
+  it('エンターキーで送信できる', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'ペインポイントをクイック作成しました' })
+    })
+
+    render(<QuickRegistration />)
+    const input = screen.getByPlaceholderText('今感じている課題を入力してください...')
+    
+    fireEvent.change(input, { target: { value: 'テストペインポイント' } })
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        `${process.env.NEXT_PUBLIC_API_URL}/pain_points/quick`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+          body: JSON.stringify({ content: 'テストペインポイント' }),
+        })
+      )
+    })
+  })
+
+  it('送信成功時にメッセージが表示される', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'ペインポイントをクイック作成しました' })
+    })
+
+    render(<QuickRegistration />)
+    const input = screen.getByPlaceholderText('今感じている課題を入力してください...')
+    
+    fireEvent.change(input, { target: { value: 'テストペインポイント' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => {
+      expect(screen.getByText('ペインポイントを登録しました')).toBeInTheDocument()
+    })
+  })
+
+  it('送信失敗時にエラーメッセージが表示される', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ message: 'エラーが発生しました' })
+    })
+
+    render(<QuickRegistration />)
+    const input = screen.getByPlaceholderText('今感じている課題を入力してください...')
+    
+    fireEvent.change(input, { target: { value: 'テストペインポイント' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => {
+      expect(screen.getByText('登録に失敗しました')).toBeInTheDocument()
+    })
+  })
+
+  it('空の入力では送信されない', () => {
+    render(<QuickRegistration />)
+    const button = screen.getByRole('button', { name: '送信' })
+    
+    expect(button).toBeDisabled()
+  })
+
+  it('送信後に入力フィールドがクリアされる', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'ペインポイントをクイック作成しました' })
+    })
+
+    render(<QuickRegistration />)
+    const input = screen.getByPlaceholderText('今感じている課題を入力してください...') as HTMLInputElement
+    
+    fireEvent.change(input, { target: { value: 'テストペインポイント' } })
+    fireEvent.submit(input.closest('form')!)
+
+    await waitFor(() => {
+      expect(input.value).toBe('')
+    })
+  })
+})


### PR DESCRIPTION
## 概要
Issue #6に対応し、ペインポイントのクイック登録機能を実装しました。
1行の入力フォームで素早くペインポイントを記録でき、エンターキーで即時保存が可能です。

## 実装内容

### フロントエンド
- `QuickRegistration.tsx` コンポーネントの作成
- エンターキーでの送信機能
- 成功/失敗の通知表示（アニメーション付き）
- モバイル対応UI（音声入力考慮、レスポンシブデザイン）
- 保存後の入力フィールド自動クリア

### バックエンド  
- `/api/v1/pain_points/quick` APIエンドポイントの実装
- パラメータ名の修正（title → content）
- バリデーション処理とエラーハンドリング
- デフォルト重要度（3）の設定

### テスト
- Jest（フロントエンド）: 入力、送信、エラーハンドリングのテスト
- Minitest（バックエンド）: APIエンドポイントの動作確認
- RSpec（バックエンド）: より詳細なテストケース

## 編集ファイル
- `frontend/components/QuickRegistration.tsx` (新規)
- `frontend/app/page.tsx` (更新: ホーム画面にコンポーネント配置)
- `frontend/app/globals.css` (更新: アニメーション追加)
- `backend/app/controllers/api/v1/pain_points_controller.rb` (更新)
- `backend/config/routes.rb` (更新)
- テストファイル複数 (新規・更新)

🤖 Generated with [Claude Code](https://claude.ai/code)