### PR TITLE
feat: 使い方セクションを中央配置で適度な幅に調整

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -72,12 +72,12 @@ export default function Home() {
           </section>
         )}
         
-        <section className="max-w-4xl mx-auto">
-          <div className="bg-card rounded-lg shadow-md p-6 border border-border">
-            <h3 className="text-xl font-semibold text-card-foreground mb-4">
+        <section className="flex justify-center">
+          <div className="bg-card rounded-lg shadow-md p-6 border border-border max-w-md">
+            <h3 className="text-xl font-semibold text-card-foreground mb-4 text-center">
               使い方
             </h3>
-            <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
+            <ol className="list-decimal list-inside space-y-2 text-muted-foreground text-left">
               <li>小さな気づきを大きなチャンスに</li>
               <li>思考の整理はAIにお任せ</li>
               <li>あなたの課題が誰かの解決策になる</li>


### PR DESCRIPTION
## 概要
使い方セクションのレイアウトを改善し、中央配置で適度な幅に調整しました。

## 実装内容
- flexboxを使用して中央配置
- 最大幅を`max-w-md`に設定（適度なサイズの枠）
- 「使い方」の見出しを中央揃えに変更
- リスト項目は左揃えを維持（読みやすさを保つため）

## 編集ファイル
- `frontend/app/page.tsx`

🤖 Generated with [Claude Code](https://claude.ai/code)