### PR TITLE
feat: ペインポイント詳細画面のボタンを改善

### DIFF
--- a/frontend/app/pain-points/[id]/page.tsx
+++ b/frontend/app/pain-points/[id]/page.tsx
@@ -134,13 +134,6 @@ export default function PainPointDetailPage({ params }: { params: Promise<{ id: 
         </Button>
         <div className="flex gap-2">
           <Button
-            variant="secondary"
-            onClick={() => setShowCreateIdeaModal(true)}
-          >
-            <Lightbulb className="w-4 h-4 mr-2" />
-            アイディアに昇華
-          </Button>
-          <Button
             variant="outline"
             onClick={() => router.push(`/pain-points/${id}/edit`)}
           >
@@ -239,11 +232,11 @@ export default function PainPointDetailPage({ params }: { params: Promise<{ id: 
         </Button>
         <Button 
           size="lg" 
-          variant="outline"
           onClick={() => setShowCreateIdeaModal(true)}
+          className="bg-yellow-500 hover:bg-yellow-600 text-white"
         >
           <Lightbulb className="w-5 h-5 mr-2" />
-          アイディアに昇華
+          アイディア化する
         </Button>
       </div>
 


### PR DESCRIPTION
## 概要
ペインポイント詳細画面のボタンレイアウトと文言を改善しました。

## 実装内容
1. **上部の重複ボタンを削除**
   - 「アイディアに昇華」ボタンを削除（下部と重複していたため）

2. **文言の変更**
   - 「アイディアに昇華」→「アイディア化する」
   - より直感的でアクション指向の表現

3. **ボタンカラー**
   - 黄色系（bg-yellow-500）を適用
   - ポジティブで創造的なイメージを演出

## 編集ファイル
- `frontend/app/pain-points/[id]/page.tsx`

🤖 Generated with [Claude Code](https://claude.ai/code)