### PR TITLE
GitHubログイン後のリダイレクト問題を修正

### DIFF
--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -44,9 +44,17 @@ function AuthCallbackContent() {
           created_at: new Date().toISOString()
         })
 
-        // リダイレクト
+        // リダイレクト前に少し待つ（状態の更新を確実にするため）
         console.log('Redirecting to home page...')
-        router.push('/')
+        setTimeout(() => {
+          // 確実にリダイレクトするため、両方の方法を試す
+          router.push('/')
+          router.refresh()
+          // それでもダメな場合のフォールバック
+          setTimeout(() => {
+            window.location.href = '/'
+          }, 500)
+        }, 100)
       } catch (error) {
         console.error('Error during OAuth callback processing:', error)
         router.push('/login?error=callback_processing_failed')

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -172,6 +172,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const setUserData = (userData: User) => {
     setUser(userData)
     setIsLoggedIn(true)
+    // トークンがlocalStorageにある場合は、それも設定
+    const storedToken = localStorage.getItem('token')
+    if (storedToken) {
+      setToken(storedToken)
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
## 概要
GitHubでサインアップした後、ログイン前のホームページに戻される問題を修正しました。

### 問題
- GitHubでサインアップ完了後、認証は成功しているがログイン前のホームページが表示される
- 一度サインアップした後は、GitHubログインは正常に動作する

### 実装内容
1. **OAuthコールバック処理の改善**
   - リダイレクト前に状態更新のための待機時間を追加
   - `router.refresh()`を使用してページを確実に更新
   - フォールバックとして`window.location.href`も使用

2. **AuthContextの改善**
   - `setUserData`関数でユーザー情報設定時にトークンも同時に設定
   - localStorageからトークンを取得して状態に反映

### 編集ファイル
- `frontend/app/auth/callback/page.tsx`
- `frontend/contexts/AuthContext.tsx`

### テスト方法
1. 既存のGitHubアカウントとの連携を解除
2. 新規にGitHubでサインアップ
3. 正しくログイン状態のホームページにリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)