### PR TITLE
UI要素の配置を改善

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -77,22 +77,26 @@ export default function Home() {
             <h3 className="text-xl font-semibold text-card-foreground mb-4 text-center">
               使い方
             </h3>
-            <ol className="list-decimal list-inside space-y-3 text-muted-foreground text-left">
-              <li>日常で感じた課題や不便をメモ感覚で記録</li>
-              <li>自動で課題を深掘り</li>
-              <li>アイディアとして記録・管理</li>
-            </ol>
+            <div className="flex justify-center">
+              <ol className="list-decimal list-inside space-y-3 text-muted-foreground text-left">
+                <li>日常で感じた課題や不便をメモ感覚で記録</li>
+                <li>自動で課題を深掘り</li>
+                <li>アイディアとして記録・管理</li>
+              </ol>
+            </div>
           </div>
           
           <div className="bg-card rounded-lg shadow-md p-6 border border-border">
             <h3 className="text-xl font-semibold text-card-foreground mb-4 text-center">
               CatIdeaの流れ
             </h3>
-            <ol className="list-decimal list-inside space-y-3 text-muted-foreground text-left">
-              <li>小さな気づきを大きなチャンスに</li>
-              <li>思考の整理はAIにお任せ</li>
-              <li>あなたの課題が誰かの解決策になる</li>
-            </ol>
+            <div className="flex justify-center">
+              <ol className="list-decimal list-inside space-y-3 text-muted-foreground text-left">
+                <li>小さな気づきを大きなチャンスに</li>
+                <li>思考の整理はAIにお任せ</li>
+                <li>あなたの課題が誰かの解決策になる</li>
+              </ol>
+            </div>
           </div>
         </section>
       </div>

--- a/frontend/app/pain-points/[id]/page.tsx
+++ b/frontend/app/pain-points/[id]/page.tsx
@@ -221,8 +221,8 @@ export default function PainPointDetailPage({ params }: { params: Promise<{ id: 
         </CardContent>
       </Card>
 
-      <div className="mt-8 space-y-4">
-        <div className="flex justify-center gap-4">
+      <div className="mt-8 flex justify-center gap-4">
+        <div className="flex flex-col items-center space-y-2">
           <Button 
             size="lg" 
             onClick={() => setShowAiProcessingModal(true)}
@@ -231,6 +231,15 @@ export default function PainPointDetailPage({ params }: { params: Promise<{ id: 
             <Sparkles className="w-5 h-5 mr-2" />
             AI自動処理
           </Button>
+          <div className="relative max-w-xs">
+            <div className="bg-muted rounded-lg p-3 text-sm text-muted-foreground relative">
+              <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent border-b-[8px] border-b-muted"></div>
+              AIが課題を分析し、構造化された洞察を提供します
+            </div>
+          </div>
+        </div>
+        
+        <div className="flex flex-col items-center space-y-2">
           <Button 
             size="lg" 
             onClick={() => setShowCreateIdeaModal(true)}
@@ -239,16 +248,6 @@ export default function PainPointDetailPage({ params }: { params: Promise<{ id: 
             <Lightbulb className="w-5 h-5 mr-2" />
             アイディア化する
           </Button>
-        </div>
-        
-        {/* ボタンの説明 */}
-        <div className="flex justify-center gap-4">
-          <div className="relative max-w-xs">
-            <div className="bg-muted rounded-lg p-3 text-sm text-muted-foreground relative">
-              <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent border-b-[8px] border-b-muted"></div>
-              AIが課題を分析し、構造化された洞察を提供します
-            </div>
-          </div>
           <div className="relative max-w-xs">
             <div className="bg-muted rounded-lg p-3 text-sm text-muted-foreground relative">
               <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent border-b-[8px] border-b-muted"></div>


### PR DESCRIPTION
## 概要
ペインポイント詳細ページとホームページのUI要素の配置を改善しました。

### 実装内容

1. **ペインポイント詳細ページの吹き出し配置**
   - ボタンと吹き出しを個別にラップして縦方向に配置
   - 各ボタンの真下に吹き出しが正しく表示されるように修正
   - `flex-col`と`items-center`で中央揃えを実現

2. **ホームページのリスト配置**
   - 「使い方」と「CatIdeaの流れ」セクションのリストを中央揃えに
   - リスト自体は左揃えを維持しながら、全体を中央に配置
   - 見出しとリストの中心が揃うように調整

### 編集ファイル
- `frontend/app/pain-points/[id]/page.tsx`
- `frontend/app/page.tsx`

### スクリーンショット
修正前：吹き出しとボタンの位置がずれていた
修正後：各要素が適切に配置されるようになった

🤖 Generated with [Claude Code](https://claude.ai/code)