### PR TITLE
fix: 本番環境での認証エラーを修正

### DIFF
--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -31,6 +31,9 @@ module App
 
     # Add middleware for session and cookies support
     config.middleware.use ActionDispatch::Cookies
-    config.middleware.use ActionDispatch::Session::CookieStore, key: '_catidea_session'
+    config.middleware.use ActionDispatch::Session::CookieStore, 
+      key: '_catidea_session',
+      same_site: :none,
+      secure: Rails.env.production?
   end
 end


### PR DESCRIPTION
## 概要
本番環境で新規登録・ログインができない問題を修正

## 問題の原因
1. フロントエンド（Vercel）とバックエンド（Render）が異なるドメインで動作
2. セッションCookieがクロスドメインで共有されない
3. CORS設定でFRONTEND_URL環境変数が未設定

## 実装内容
- セッションCookieの設定を修正
  - `same_site: :none` - 異なるサイト間でのCookie送信を許可
  - `secure: true` (本番環境のみ) - HTTPS通信でのみCookieを送信

## 必要な追加設定
Renderの環境変数に以下を追加する必要があります：
```
FRONTEND_URL=https://cat-idea.vercel.app
```

## 編集ファイル
- backend/config/application.rb: セッションCookie設定の修正

🤖 Generated with [Claude Code](https://claude.ai/code)