### PR TITLE
feat: UI改善 - ナビゲーションとフィードバックの向上

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -80,7 +80,7 @@ export default function Home() {
             <div className="flex justify-center">
               <ol className="list-decimal list-inside space-y-3 text-muted-foreground text-left">
                 <li>日常で感じた課題や不便をメモ感覚で記録</li>
-                <li>自動で課題を深掘り</li>
+                <li>ペインポイントを自動で深掘り</li>
                 <li>アイディアとして記録・管理</li>
               </ol>
             </div>

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import { ToastProvider } from '@/contexts/ToastContext'
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   return (
@@ -11,7 +12,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       disableTransitionOnChange
       suppressHydrationWarning
     >
-      {children}
+      <ToastProvider>
+        {children}
+      </ToastProvider>
     </NextThemesProvider>
   )
 }

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { useAuth } from '@/contexts/AuthContext'
 import { ThemeToggle } from './ThemeToggle'
 import { CatLoadingInline } from '@/components/ui/cat-loading'
@@ -9,6 +10,7 @@ import { CatLoadingInline } from '@/components/ui/cat-loading'
 export default function Header() {
   const { user, isLoggedIn, logout, isLoading } = useAuth()
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const pathname = usePathname()
 
   const handleLogout = async () => {
     await logout()
@@ -52,7 +54,11 @@ export default function Header() {
           <nav className="hidden md:flex space-x-8">
             <Link 
               href="/" 
-              className="text-muted-foreground hover:text-foreground px-3 py-2 rounded-md text-sm font-medium transition-colors"
+              className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                pathname === '/' 
+                  ? 'text-primary bg-primary/10' 
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
             >
               ホーム
             </Link>
@@ -60,13 +66,21 @@ export default function Header() {
               <>
                 <Link 
                   href="/pain-points" 
-                  className="text-muted-foreground hover:text-foreground px-3 py-2 rounded-md text-sm font-medium transition-colors"
+                  className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                    pathname?.startsWith('/pain-points') 
+                      ? 'text-primary bg-primary/10' 
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
                 >
                   ペインポイント
                 </Link>
                 <Link 
                   href="/ideas" 
-                  className="text-muted-foreground hover:text-foreground px-3 py-2 rounded-md text-sm font-medium transition-colors"
+                  className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                    pathname?.startsWith('/ideas') 
+                      ? 'text-primary bg-primary/10' 
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
                 >
                   アイディア
                 </Link>
@@ -137,7 +151,11 @@ export default function Header() {
               <Link 
                 href="/" 
                 onClick={() => setIsMobileMenuOpen(false)}
-                className="block text-muted-foreground hover:text-foreground px-3 py-2 rounded-md text-base font-medium transition-colors"
+                className={`block px-3 py-2 rounded-md text-base font-medium transition-colors ${
+                  pathname === '/' 
+                    ? 'text-primary bg-primary/10' 
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
               >
                 ホーム
               </Link>
@@ -146,14 +164,22 @@ export default function Header() {
                   <Link 
                     href="/pain-points" 
                     onClick={() => setIsMobileMenuOpen(false)}
-                    className="block text-muted-foreground hover:text-foreground px-3 py-2 rounded-md text-base font-medium transition-colors"
+                    className={`block px-3 py-2 rounded-md text-base font-medium transition-colors ${
+                      pathname?.startsWith('/pain-points') 
+                        ? 'text-primary bg-primary/10' 
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
                   >
                     ペインポイント
                   </Link>
                   <Link 
                     href="/ideas" 
                     onClick={() => setIsMobileMenuOpen(false)}
-                    className="block text-muted-foreground hover:text-foreground px-3 py-2 rounded-md text-base font-medium transition-colors"
+                    className={`block px-3 py-2 rounded-md text-base font-medium transition-colors ${
+                      pathname?.startsWith('/ideas') 
+                        ? 'text-primary bg-primary/10' 
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
                   >
                     アイディア
                   </Link>

--- a/frontend/components/QuickRegistration.tsx
+++ b/frontend/components/QuickRegistration.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useState, FormEvent, KeyboardEvent } from 'react'
+import { useRouter } from 'next/navigation'
 import { apiClient } from '@/lib/api-client'
+import { useToast } from '@/contexts/ToastContext'
 
 interface QuickRegistrationProps {
   onSuccess?: () => void
@@ -12,6 +14,8 @@ export default function QuickRegistration({ onSuccess }: QuickRegistrationProps)
   const [isLoading, setIsLoading] = useState(false)
   const [message, setMessage] = useState<{ type: 'success' | 'error', text: string } | null>(null)
   const [isComposing, setIsComposing] = useState(false)
+  const router = useRouter()
+  const { showToast } = useToast()
 
   const handleSubmit = async (e?: FormEvent) => {
     e?.preventDefault()
@@ -29,6 +33,14 @@ export default function QuickRegistration({ onSuccess }: QuickRegistrationProps)
       setContent('')
       setMessage({ type: 'success', text: 'ペインポイントを登録しました' })
       onSuccess?.()
+      
+      // トースト通知を表示
+      showToast('ペインポイントを登録しました！ペインポイント一覧で確認できます。', 'success')
+      
+      // 3秒後にペインポイント一覧へ誘導
+      setTimeout(() => {
+        router.push('/pain-points')
+      }, 3000)
       
       setTimeout(() => setMessage(null), 3000)
     } catch {

--- a/frontend/components/ui/toast.tsx
+++ b/frontend/components/ui/toast.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+
+interface ToastProps {
+  message: string
+  type?: 'success' | 'error' | 'info'
+  duration?: number
+  onClose?: () => void
+}
+
+export function Toast({ message, type = 'success', duration = 5000, onClose }: ToastProps) {
+  const [isVisible, setIsVisible] = useState(true)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsVisible(false)
+      onClose?.()
+    }, duration)
+
+    return () => clearTimeout(timer)
+  }, [duration, onClose])
+
+  if (!isVisible) return null
+
+  const typeClasses = {
+    success: 'bg-green-500 text-white',
+    error: 'bg-red-500 text-white',
+    info: 'bg-blue-500 text-white',
+  }
+
+  return (
+    <div className={`fixed top-20 right-4 z-50 flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg transition-all duration-300 max-w-md ${typeClasses[type]}`}>
+      <span className="text-sm font-medium">{message}</span>
+      <button
+        onClick={() => {
+          setIsVisible(false)
+          onClose?.()
+        }}
+        className="p-1 hover:bg-white/20 rounded transition-colors"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}
+
+// トーストを管理するためのフック
+export function useToast() {
+  const [toasts, setToasts] = useState<Array<{ id: string; message: string; type?: 'success' | 'error' | 'info' }>>([])
+
+  const showToast = (message: string, type: 'success' | 'error' | 'info' = 'success') => {
+    const id = Date.now().toString()
+    setToasts(prev => [...prev, { id, message, type }])
+  }
+
+  const removeToast = (id: string) => {
+    setToasts(prev => prev.filter(toast => toast.id !== id))
+  }
+
+  return { toasts, showToast, removeToast }
+}

--- a/frontend/contexts/ToastContext.tsx
+++ b/frontend/contexts/ToastContext.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import React, { createContext, useContext, useState, ReactNode } from 'react'
+import { Toast } from '@/components/ui/toast'
+
+interface ToastContextType {
+  showToast: (message: string, type?: 'success' | 'error' | 'info') => void
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined)
+
+export const useToast = () => {
+  const context = useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+  return context
+}
+
+interface ToastProviderProps {
+  children: ReactNode
+}
+
+export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
+  const [toasts, setToasts] = useState<Array<{ id: string; message: string; type?: 'success' | 'error' | 'info' }>>([])
+
+  const showToast = (message: string, type: 'success' | 'error' | 'info' = 'success') => {
+    const id = Date.now().toString()
+    setToasts(prev => [...prev, { id, message, type }])
+  }
+
+  const removeToast = (id: string) => {
+    setToasts(prev => prev.filter(toast => toast.id !== id))
+  }
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {toasts.map(toast => (
+        <Toast
+          key={toast.id}
+          message={toast.message}
+          type={toast.type}
+          onClose={() => removeToast(toast.id)}
+        />
+      ))}
+    </ToastContext.Provider>
+  )
+}


### PR DESCRIPTION
## 概要
ユーザー体験を向上させるためのUI改善を実施

## 実装内容

### 1. トップページの文言改善
- 「使い方」セクションの2番目を「ペインポイントを自動で深掘り」に変更
- ペインポイントページへ移動することを明確に

### 2. ナビゲーションの改善
- ヘッダーに現在のページをハイライト表示する機能を追加
- アクティブなページは青色背景で強調表示
- デスクトップとモバイル両方で対応

### 3. フィードバック機能の追加
- トースト通知コンポーネントを新規作成
- ペインポイント登録成功時にトースト通知を表示
- 「ペインポイントを登録しました！ペインポイント一覧で確認できます。」というメッセージ
- 3秒後に自動的にペインポイント一覧ページへ遷移

## 編集ファイル
- frontend/app/page.tsx: 使い方の文言変更
- frontend/components/Header.tsx: アクティブ状態の表示機能追加
- frontend/components/QuickRegistration.tsx: トースト通知と自動遷移機能追加
- frontend/components/ui/toast.tsx: トーストコンポーネント（新規）
- frontend/contexts/ToastContext.tsx: トーストコンテキスト（新規）
- frontend/app/providers.tsx: ToastProviderの追加

🤖 Generated with [Claude Code](https://claude.ai/code)