### PR TITLE
fix: CORS設定のデフォルトURLを修正

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -11,7 +11,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       origins "http://localhost:3001", "http://127.0.0.1:3001"
     else
       # 本番環境では環境変数でフロントエンドのURLを指定
-      frontend_url = ENV["FRONTEND_URL"] || "https://your-app.vercel.app"
+      frontend_url = ENV["FRONTEND_URL"] || "https://cat-idea.vercel.app"
       origins frontend_url
     end
 


### PR DESCRIPTION
## 概要
CORS設定のデフォルトURLを実際のフロントエンドURLに修正

## 変更内容
- `config/initializers/cors.rb` のデフォルトURL設定を修正
- 変更前: `"https://your-app.vercel.app"`
- 変更後: `"https://cat-idea.vercel.app"`

## 修正の理由
環境変数 `FRONTEND_URL` が何らかの理由で読み込まれなかった場合に備えて、デフォルト値を実際のフロントエンドURLに設定することで、より堅牢な設定にしました。

## 影響範囲
- 通常は環境変数が優先されるため、既存の動作に影響なし
- 環境変数が未設定の場合のフェイルセーフとして機能

🤖 Generated with [Claude Code](https://claude.ai/code)