### PR TITLE
fix: タグ入力後に入力値が残る問題を修正

### DIFF
--- a/frontend/components/TagInput.tsx
+++ b/frontend/components/TagInput.tsx
@@ -76,10 +76,11 @@ export default function TagInput({
       value.length < maxTags
     ) {
       onChange([...value, trimmedTag])
+      // タグ追加後は必ず入力値をクリア
+      setInputValue('')
+      setIsOpen(false)
+      setHighlightedIndex(-1)
     }
-    setInputValue('')
-    setIsOpen(false)
-    setHighlightedIndex(-1)
   }
 
   const removeTag = (indexToRemove: number) => {
@@ -94,8 +95,6 @@ export default function TagInput({
       } else if (inputValue.trim()) {
         addTag(inputValue)
       }
-      // Enterキー押下後は必ず入力値をクリア
-      setInputValue('')
     } else if (e.key === 'ArrowDown') {
       e.preventDefault()
       setHighlightedIndex(prev => 
@@ -185,7 +184,10 @@ export default function TagInput({
                     ? 'bg-primary/10 text-primary' 
                     : 'text-popover-foreground'
                 }`}
-                onClick={() => addTag(suggestion)}
+                onClick={() => {
+                  addTag(suggestion)
+                  setInputValue('') // 明示的にクリア
+                }}
                 onMouseEnter={() => setHighlightedIndex(index)}
               >
                 {suggestion}


### PR DESCRIPTION
## 概要
タグ入力コンポーネントで、Enterキーでタグを追加した後も入力欄に文字が残ってしまう問題を修正しました。

### 修正内容
1. `addTag`関数内で、タグ追加成功時のみ入力値をクリアするように変更
2. 候補リストからタグを選択した際も明示的に入力値をクリア
3. `handleKeyDown`関数内の重複したクリア処理を削除

### 編集ファイル
- `frontend/components/TagInput.tsx`

### テスト手順
1. ペインポイント作成/編集画面でタグ入力欄に文字を入力
2. Enterキーを押してタグを追加
3. 入力欄が空になることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)